### PR TITLE
Feat/nighthom e2e eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ python scripts/predict.py \
     --source data/raw/test/
 
 python scripts/make_submission.py \
-    --predictions experiments/exp_20260420_baseline_yolo26n/results/predictions.json \
-    --output submissions/submission.csv
+    --manifest  experiments/exp_20260420_baseline_yolo26n/stage1_crops/crops_manifest.json \
+    --s2-preds  experiments/exp_20260420_baseline_yolo26n/stage2_predictions.json \
+    --class-map data/processed/kaggle_class_map.json \
+    --output    submissions/submission.csv
 ```
 
 ### Stage 2 단독 실행

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ CLI 실행 스크립트입니다. **프로젝트 루트**에서 실행하세요.
 | `train.py` | config를 읽어 모델 학습 → 가중치 저장 | 승준 |
 | `predict.py` | 저장된 가중치로 이미지 추론 → predictions.json 저장 | 승준 |
 | `validate.py` | 저장된 가중치로 val set 평가 → mAP 출력 | 승준 |
-| `make_submission.py` | predictions.json → Kaggle 제출용 submission.csv 변환 | 도혁 |
+| `make_submission.py` | crops_manifest + stage2_predictions → Kaggle 제출용 submission.csv 변환 (score = det×cls, category_id 매핑 적용) | 도혁 |
 | `convert_annotations.py` | src/data 모듈을 이용해 raw/external 어노테이션을 YOLO 라벨로 변환 | 소원 |
 
 
@@ -25,6 +25,7 @@ CLI 실행 스크립트입니다. **프로젝트 루트**에서 실행하세요.
 | `pipeline/stage2_predict.py` | 크롭 이미지 분류 → stage2_predictions.json 저장 |
 | `pipeline/run_train.py` | Stage 1 학습 → Stage 2 학습 통합 실행 |
 | `pipeline/run_predict.py` | Stage 1 추론 → 크롭(inference 모드 자동) → Stage 2 추론 → submission.csv 통합 실행 |
+| `pipeline/evaluate_pipeline.py` | GT labels + S1 crops manifest + S2 predictions → end-to-end mAP@[0.50:0.95] / mAP@[0.75:0.95] 계산 (로컬 Kaggle 점수 추정) |
 
 ---
 
@@ -42,12 +43,6 @@ data/raw/train/   experiments/.../config.yaml
         │         experiments/.../config.yaml
         ▼                  │
   [ predict.py ] ──────────┘  →  experiments/.../results/predictions.json
-                                               │
-                                               ▼
-                                   [ make_submission.py ]
-                                               │
-                                               ▼
-                                   submissions/submission.csv
 ```
 
 ### 2단계 파이프라인 전체 흐름
@@ -98,10 +93,13 @@ data/raw/train/   experiments/.../config.yaml
   [ pipeline/stage2_predict.py ]  브랜드명 분류
       │  stage2_predictions.json
       ▼
-  [ make_submission.py ]          bbox + class 병합
-      │
+  [ make_submission.py ]          Kaggle category_id 매핑 + CSV 생성
+      │  --manifest crops_manifest.json
+      │  --s2-preds stage2_predictions.json
+      │  --class-map kaggle_class_map.json
       ▼
   submissions/submission.csv
+      score = det_score × cls_score
 ```
 
 `validate.py`는 파이프라인과 별도로, 학습 완료 후 val set 성능을 확인할 때 독립적으로 사용합니다.
@@ -128,10 +126,12 @@ python scripts/predict.py \
     --weights experiments/stage1_detection/weights/best.pt \
     --source  data/raw/test/
 
-# 제출 파일 생성
+# 제출 파일 생성 (2-stage 파이프라인 결과)
 python scripts/make_submission.py \
-    --predictions experiments/stage1_detection/results/predictions.json \
-    --output submissions/submission.csv
+    --manifest  experiments/{EXP}/stage1_crops/crops_manifest.json \
+    --s2-preds  experiments/{EXP}/stage2_predictions.json \
+    --class-map data/processed/kaggle_class_map.json \
+    --output    submissions/submission.csv
 
 # 어노테이션 변환
 python -m scripts.convert_annotations --project-root .
@@ -208,8 +208,13 @@ python scripts/pipeline/run_predict.py \
 
 | 인자 | 필수 | 기본값 | 설명 |
 |------|------|--------|------|
-| `--predictions` | ✅ | — | predictions.json 경로 |
+| `--manifest` | ✅ | — | crops_manifest.json 경로 (Stage 1 crop 메타) |
+| `--s2-preds` | ✅ | — | stage2_predictions.json 경로 |
 | `--output` | ✅ | — | submission.csv 저장 경로 |
+| `--class-map` | | — | Kaggle category_id 매핑 JSON `{class_name: id}` |
+| `--image-id-map` | | — | Kaggle image_id 매핑 JSON `{stem: int}` |
+
+score = `det_score` (manifest) × `cls_score` (stage2_predictions)
 
 ### convert_annotations.py
 
@@ -388,7 +393,7 @@ Stage 1은 단일 클래스 탐지기이므로 `class_id`와 `class_name`은 기
     "image_id":   "test_0001",
     "crop_id":    "test_0001_0",
     "class_id":   42,
-    "class_name": "Crestor 10mg tab",
+    "class_name": "crestor_tab_20mg",
     "score":      0.912
   }
 ]
@@ -400,7 +405,9 @@ Stage 1은 단일 클래스 탐지기이므로 `class_id`와 `class_name`은 기
 
 ```
 annotation_id, image_id, category_id, bbox_x, bbox_y, bbox_w, bbox_h, score
-1, test_0001, 42, 120, 45, 260, 165, 0.91
+1, 1, 16262, 120, 45, 260, 165, 0.84
 ```
 
-`crops_manifest.json`의 bbox + `stage2_predictions.json`의 class_id를 `crop_id` 기준으로 병합해 생성.
+- `category_id`: `kaggle_class_map.json` 기준 Kaggle dl_idx (예: crestor_tab_20mg → 16262)
+- `score`: `crops_manifest.json`의 det_score × `stage2_predictions.json`의 cls_score
+- `crops_manifest.json`의 bbox + `stage2_predictions.json`의 class를 `crop_id` 기준으로 병합해 생성.

--- a/scripts/make_submission.py
+++ b/scripts/make_submission.py
@@ -1,19 +1,27 @@
 """
 Kaggle 제출 CSV 생성 CLI.
 
-predictions.json을 읽어 대회 제출 포맷(submission.csv)으로 변환한다.
-
-predictions.json 포맷:
-    [{"image_id": "1", "detections": [{"class_id": int, "class_name": str, "bbox": [x1,y1,x2,y2], "score": float}]}]
+crops_manifest.json + stage2_predictions.json → submission.csv
 
 submission.csv 포맷:
     annotation_id, image_id, category_id, bbox_x, bbox_y, bbox_w, bbox_h, score
     1, 1, 1, 156, 247, 211, 456, 0.91
 
+score = det_score (Stage 1) × cls_score (Stage 2).
+
 사용 예:
     python scripts/make_submission.py \\
-        --predictions results/predictions.json \\
-        --output submissions/submission.csv
+        --manifest  experiments/.../stage1_crops/crops_manifest.json \\
+        --s2-preds  experiments/.../stage2_predictions.json \\
+        --output    submissions/submission.csv
+
+    # Kaggle category_id 매핑 적용 (class_name → category_id)
+    python scripts/make_submission.py ... \\
+        --class-map data/processed/kaggle_class_map.json
+
+    # Kaggle image_id 매핑 적용 (filename_stem → numeric id)
+    python scripts/make_submission.py ... \\
+        --image-id-map data/processed/kaggle_image_id_map.json
 """
 
 import argparse
@@ -32,19 +40,36 @@ sys.path.insert(
     ),
 )
 
-from src.utils.submission import save_submission
+from src.utils.submission import merge_predictions, save_submission
+
+
+def _load_json_map(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Kaggle 제출 CSV 생성")
-    parser.add_argument("--predictions", required=True, help="predictions.json 경로")
-    parser.add_argument("--output", required=True, help="submission.csv 저장 경로")
+    parser.add_argument("--manifest",   required=True, help="crops_manifest.json 경로")
+    parser.add_argument("--s2-preds",   required=True, help="stage2_predictions.json 경로")
+    parser.add_argument("--output",     required=True, help="submission.csv 저장 경로")
+    parser.add_argument(
+        "--class-map",
+        default=None,
+        help="Kaggle category_id 매핑 JSON {class_name: category_id} (미지정 시 내부 class_id 사용)",
+    )
+    parser.add_argument(
+        "--image-id-map",
+        default=None,
+        help="Kaggle image_id 매핑 JSON {filename_stem: int} (미지정 시 파일명 그대로 사용)",
+    )
     args = parser.parse_args()
 
-    with open(args.predictions, encoding="utf-8") as f:
-        predictions = json.load(f)
+    class_map = _load_json_map(args.class_map) if args.class_map else None
+    image_id_map = _load_json_map(args.image_id_map) if args.image_id_map else None
 
-    save_submission(predictions, args.output)
+    predictions = merge_predictions(args.manifest, args.s2_preds)
+    save_submission(predictions, args.output, class_map=class_map, image_id_map=image_id_map)
     print(f"제출 파일 생성 완료: {args.output}")
 
 

--- a/scripts/make_submission.py
+++ b/scripts/make_submission.py
@@ -50,9 +50,11 @@ def _load_json_map(path: str) -> dict:
 
 def main():
     parser = argparse.ArgumentParser(description="Kaggle 제출 CSV 생성")
-    parser.add_argument("--manifest",   required=True, help="crops_manifest.json 경로")
-    parser.add_argument("--s2-preds",   required=True, help="stage2_predictions.json 경로")
-    parser.add_argument("--output",     required=True, help="submission.csv 저장 경로")
+    parser.add_argument("--manifest", required=True, help="crops_manifest.json 경로")
+    parser.add_argument(
+        "--s2-preds", required=True, help="stage2_predictions.json 경로"
+    )
+    parser.add_argument("--output", required=True, help="submission.csv 저장 경로")
     parser.add_argument(
         "--class-map",
         default=None,
@@ -69,7 +71,9 @@ def main():
     image_id_map = _load_json_map(args.image_id_map) if args.image_id_map else None
 
     predictions = merge_predictions(args.manifest, args.s2_preds)
-    save_submission(predictions, args.output, class_map=class_map, image_id_map=image_id_map)
+    save_submission(
+        predictions, args.output, class_map=class_map, image_id_map=image_id_map
+    )
     print(f"제출 파일 생성 완료: {args.output}")
 
 

--- a/scripts/pipeline/README.md
+++ b/scripts/pipeline/README.md
@@ -400,7 +400,7 @@ python scripts/pipeline/run_predict.py \
 **코드:**
 ```bash
 python scripts/pipeline/crop.py \
-    --predictions experiments/exp_20260420_baseline_yolo26n/val_predictions.json \
+    --predictions experiments/exp_20260420_baseline_yolo26n/results/predictions.json \
     --source      data/processed/images/val/ \
     --output      experiments/exp_20260420_baseline_yolo26n/stage1_crops/ \
     --padding     0.05
@@ -519,10 +519,10 @@ data/processed/crops/
 #### Mode 2: `crop_from_predictions()` - Inference Crop 생성
 ```bash
 python scripts/pipeline/crop.py \
-    --predictions experiments/{EXP}/val_predictions.json \  # Stage 1 결과
-    --source      data/processed/images/val/ \              # 원본 이미지
-    --output      experiments/{EXP}/stage1_crops/           # 출력
-    --padding     0.05                                      # 여백
+    --predictions experiments/{EXP}/results/predictions.json \  # Stage 1 결과
+    --source      data/processed/images/val/ \                  # 원본 이미지
+    --output      experiments/{EXP}/stage1_crops/               # 출력
+    --padding     0.05                                          # 여백
 ```
 
 **입력:**
@@ -654,6 +654,35 @@ python scripts/pipeline/stage2_predict.py \
   "score": 0.92
 }
 ```
+---
+
+### 6. `evaluate_pipeline.py` - End-to-end mAP 평가
+
+```bash
+python scripts/pipeline/evaluate_pipeline.py \
+    --gt-labels data/processed/labels/val \
+    --gt-images data/processed/images/val \
+    --s1-crops  experiments/{EXP}/stage1_crops/crops_manifest.json \
+    --s2-preds  experiments/{EXP}/stage2_predictions.json
+
+# 클래스별 AP 상위 20개 추가 출력
+python scripts/pipeline/evaluate_pipeline.py ... --per-class
+```
+
+**출력:**
+```
+GT     : 497장  547개 객체
+Pred   : 547개 / 44클래스 평가
+mAP@[0.50:0.95] : 0.xxxx  (COCO)
+mAP@[0.75:0.95] : 0.xxxx  (Kaggle 평가지표)
+mAP@0.50        : 0.xxxx
+mAP@0.75        : 0.xxxx
+```
+
+**주의:**
+- GT class는 파일명에서 자동 추출 (`_extract_class_name` 정규화)
+- 파일명에 약품명이 없는 iOS/IMG 이미지는 `known_classes` 필터로 자동 제외
+- score = `det_score × cls_score` (crops_manifest × stage2_predictions)
 
 ---
 
@@ -669,19 +698,25 @@ python scripts/pipeline/stage2_predict.py \
    → experiments/stage2_classifier/.../best.pt
 
 3️⃣ Stage 1 추론
-   run_predict.py
-   → experiments/{EXP}/val_predictions.json
+   predict.py
+   → experiments/{EXP}/results/predictions.json
 
 4️⃣ Inference Crop 생성
-   crop_from_predictions()
-   → experiments/{EXP}/stage1_crops/
+   crop.py (inference 모드)
+   → experiments/{EXP}/stage1_crops/ + crops_manifest.json
 
 5️⃣ Stage 2 추론
    stage2_predict.py
    → experiments/{EXP}/stage2_predictions.json
 
-6️⃣ 최종 결과
-   {이미지, 위치(bbox), 약품명, 신뢰도}
+6️⃣ [선택] End-to-end mAP 평가
+   evaluate_pipeline.py
+   → mAP@[0.50:0.95], mAP@[0.75:0.95] 출력
+
+7️⃣ Kaggle 제출 CSV 생성
+   make_submission.py --class-map kaggle_class_map.json
+   → submissions/submission.csv
+      score = det_score × cls_score
 ```
 
 ---

--- a/scripts/pipeline/crop.py
+++ b/scripts/pipeline/crop.py
@@ -57,6 +57,8 @@ sys.path.insert(
 
 from PIL import Image
 
+from src.utils.timing import timed
+
 _IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"]
 
 
@@ -337,9 +339,10 @@ def main() -> None:
     if args.predictions:
         if not args.source:
             parser.error("inference 모드: --source 가 필요합니다")
-        manifest = crop_from_predictions(
-            args.predictions, args.source, output, args.padding
-        )
+        with timed(output.parent, "crop"):
+            manifest = crop_from_predictions(
+                args.predictions, args.source, output, args.padding
+            )
         print(f"크롭 완료: {len(manifest)}개 → {output}")
     elif args.labels:
         if not args.images:

--- a/scripts/pipeline/evaluate_pipeline.py
+++ b/scripts/pipeline/evaluate_pipeline.py
@@ -1,0 +1,297 @@
+"""2-Stage 파이프라인 end-to-end mAP50 평가 스크립트.
+
+YOLO val label txt + 원본 이미지 → GT 구성
+Stage 1 crops manifest + Stage 2 predictions → 예측 구성
+→ end-to-end mAP50 계산
+
+GT 클래스명은 파일명에서 추출 후 정규화 (소문자, 하이픈→언더스코어).
+iOS/IMG 파일처럼 파일명에 약품명이 없는 경우 Stage 2가 모르는 클래스로 처리되어
+자동으로 평가에서 제외된다.
+
+사용 예:
+    python scripts/pipeline/evaluate_pipeline.py \\
+        --gt-labels data/processed/labels/val \\
+        --gt-images data/processed/images/val \\
+        --s1-crops  experiments/exp_.../stage1_crops/crops_manifest.json \\
+        --s2-preds  experiments/exp_.../stage2_predictions.json
+
+    # 클래스별 AP 상위 20개 출력
+    python scripts/pipeline/evaluate_pipeline.py ... --per-class
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+sys.path.insert(
+    0,
+    str(
+        next(
+            p
+            for p in Path(__file__).resolve().parents
+            if (p / "requirements.txt").exists()
+        )
+    ),
+)
+
+from scripts.pipeline.crop import _extract_class_name
+
+_IMAGE_EXTS = [".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"]
+
+
+# ---------------------------------------------------------------------------
+# IoU / AP
+# ---------------------------------------------------------------------------
+
+
+def _iou(a: list[float], b: list[float]) -> float:
+    ix1, iy1 = max(a[0], b[0]), max(a[1], b[1])
+    ix2, iy2 = min(a[2], b[2]), min(a[3], b[3])
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = (a[2] - a[0]) * (a[3] - a[1]) + (b[2] - b[0]) * (b[3] - b[1]) - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _ap(recalls: np.ndarray, precisions: np.ndarray) -> float:
+    mrec = np.concatenate([[0.0], recalls, [1.0]])
+    mpre = np.concatenate([[1.0], precisions, [0.0]])
+    for i in range(len(mpre) - 2, -1, -1):
+        mpre[i] = max(mpre[i], mpre[i + 1])
+    idx = np.where(mrec[1:] != mrec[:-1])[0]
+    return float(np.sum((mrec[idx + 1] - mrec[idx]) * mpre[idx + 1]))
+
+
+# ---------------------------------------------------------------------------
+# mAP
+# ---------------------------------------------------------------------------
+
+
+def compute_map(
+    gt: dict[str, list[dict]],
+    preds: dict[str, list[dict]],
+    iou_thrs: list[float] | None = None,
+    known_classes: set[str] | None = None,
+) -> dict:
+    """여러 IoU threshold에 대해 mAP 계산.
+
+    iou_thrs 기본값: [0.50, 0.55, ..., 0.95] (COCO 스타일)
+    known_classes 지정 시 해당 클래스만 평가 (iOS 등 파일명 노이즈 제거).
+
+    Returns:
+        {
+            "mAP@[0.50:0.95]": float,
+            "mAP@[0.75:0.95]": float,
+            "mAP@0.50": float,
+            "mAP@0.75": float,
+            "per_class": {cls: {"AP@0.50": ..., "AP@0.75": ..., "AP@[0.50:0.95]": ...}},
+            "n_classes": int,
+        }
+    """
+    if iou_thrs is None:
+        iou_thrs = [round(t, 2) for t in np.arange(0.50, 1.00, 0.05)]
+
+    gt_by_class: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+    gt_count: dict[str, int] = defaultdict(int)
+    for img_id, objs in gt.items():
+        for obj in objs:
+            cls = obj["class_name"]
+            if known_classes and cls not in known_classes:
+                continue
+            gt_by_class[cls][img_id].append({"bbox": obj["bbox"]})
+            gt_count[cls] += 1
+
+    pred_by_class: dict[str, list[dict]] = defaultdict(list)
+    for img_id, dets in preds.items():
+        for det in dets:
+            pred_by_class[det["class_name"]].append(
+                {"image_id": img_id, "bbox": det["bbox"], "score": det["score"]}
+            )
+
+    # {cls: {iou_thr: ap}}
+    ap_table: dict[str, dict[float, float]] = {}
+
+    for cls in gt_count:
+        class_preds = sorted(pred_by_class.get(cls, []), key=lambda x: -x["score"])
+        n_gt = gt_count[cls]
+        ap_table[cls] = {}
+
+        for thr in iou_thrs:
+            class_gt = {
+                img_id: [{"bbox": g["bbox"], "matched": False} for g in gs]
+                for img_id, gs in gt_by_class[cls].items()
+            }
+            tp = np.zeros(len(class_preds))
+            fp = np.zeros(len(class_preds))
+            for i, pred in enumerate(class_preds):
+                best_iou, best_j = 0.0, -1
+                for j, g in enumerate(class_gt.get(pred["image_id"], [])):
+                    if g["matched"]:
+                        continue
+                    iou = _iou(pred["bbox"], g["bbox"])
+                    if iou > best_iou:
+                        best_iou, best_j = iou, j
+                if best_iou >= thr:
+                    class_gt[pred["image_id"]][best_j]["matched"] = True
+                    tp[i] = 1
+                else:
+                    fp[i] = 1
+            tp_cum = np.cumsum(tp)
+            fp_cum = np.cumsum(fp)
+            recalls = tp_cum / n_gt
+            precisions = tp_cum / (tp_cum + fp_cum + 1e-9)
+            ap_table[cls][thr] = _ap(recalls, precisions)
+
+    def _mean_ap(thrs: list[float]) -> float:
+        if not ap_table:
+            return 0.0
+        return float(np.mean([
+            np.mean([ap_table[cls].get(t, 0.0) for t in thrs])
+            for cls in ap_table
+        ]))
+
+    thrs_5095 = [t for t in iou_thrs if 0.50 <= t <= 0.95]
+    thrs_7595 = [t for t in iou_thrs if 0.75 <= t <= 0.95]
+
+    per_class = {
+        cls: {
+            "AP@0.50": ap_table[cls].get(0.50, 0.0),
+            "AP@0.75": ap_table[cls].get(0.75, 0.0),
+            "AP@[0.50:0.95]": float(np.mean([ap_table[cls].get(t, 0.0) for t in thrs_5095])),
+            "AP@[0.75:0.95]": float(np.mean([ap_table[cls].get(t, 0.0) for t in thrs_7595])),
+        }
+        for cls in ap_table
+    }
+
+    return {
+        "mAP@[0.50:0.95]": _mean_ap(thrs_5095),
+        "mAP@[0.75:0.95]": _mean_ap(thrs_7595),
+        "mAP@0.50": _mean_ap([0.50]),
+        "mAP@0.75": _mean_ap([0.75]),
+        "per_class": per_class,
+        "n_classes": len(ap_table),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 데이터 로드
+# ---------------------------------------------------------------------------
+
+
+def _normalize(name: str) -> str:
+    return name.lower().replace("-", "_")
+
+
+def load_gt(label_dir: Path, image_dir: Path) -> dict[str, list[dict]]:
+    """YOLO label txt + 이미지 → {image_id: [{bbox(pixel), class_name}]}"""
+    gt: dict[str, list] = defaultdict(list)
+    for label_file in sorted(label_dir.glob("*.txt")):
+        stem = label_file.stem
+        class_name = _normalize(_extract_class_name(stem))
+
+        img_path = next(
+            (image_dir / f"{stem}{e}" for e in _IMAGE_EXTS
+             if (image_dir / f"{stem}{e}").exists()),
+            None,
+        )
+        if img_path is None:
+            continue
+
+        with Image.open(img_path) as img:
+            W, H = img.size
+
+        for line in label_file.read_text().strip().splitlines():
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            _, cx, cy, bw, bh = map(float, parts[:5])
+            gt[stem].append({
+                "bbox": [
+                    (cx - bw / 2) * W, (cy - bh / 2) * H,
+                    (cx + bw / 2) * W, (cy + bh / 2) * H,
+                ],
+                "class_name": class_name,
+            })
+    return dict(gt)
+
+
+def load_preds(
+    s1_crops_manifest: Path, s2_preds_path: Path
+) -> tuple[dict[str, list[dict]], set[str]]:
+    """S1 crops + S2 preds → ({image_id: [{bbox, class_name, score}]}, known_classes)
+
+    score = det_score * cls_score
+    """
+    with open(s1_crops_manifest, encoding="utf-8") as f:
+        s1_crops = json.load(f)
+    with open(s2_preds_path, encoding="utf-8") as f:
+        s2_preds = json.load(f)
+
+    s2_by_crop = {r["crop_id"]: r for r in s2_preds}
+    known_classes = {r["class_name"] for r in s2_preds}
+
+    preds: dict[str, list] = defaultdict(list)
+    for crop in s1_crops:
+        s2 = s2_by_crop.get(crop["crop_id"])
+        if s2 is None:
+            continue
+        preds[crop["image_id"]].append({
+            "bbox": crop["bbox"],
+            "class_name": s2["class_name"],
+            "score": crop["score"] * s2["score"],
+        })
+    return dict(preds), known_classes
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="2-Stage 파이프라인 end-to-end mAP 평가")
+    parser.add_argument("--gt-labels", required=True, help="YOLO label 디렉터리 (val)")
+    parser.add_argument("--gt-images", required=True, help="원본 이미지 디렉터리 (val)")
+    parser.add_argument("--s1-crops",  required=True, help="Stage 1 crops manifest")
+    parser.add_argument("--s2-preds",  required=True, help="Stage 2 predictions JSON")
+    parser.add_argument("--per-class", action="store_true", help="클래스별 AP 출력")
+    args = parser.parse_args()
+
+    gt = load_gt(Path(args.gt_labels), Path(args.gt_images))
+    preds, known_classes = load_preds(Path(args.s1_crops), Path(args.s2_preds))
+
+    n_gt_imgs = len(gt)
+    n_gt_objs = sum(len(v) for v in gt.values())
+    n_pred_objs = sum(len(v) for v in preds.values())
+
+    result = compute_map(gt, preds, known_classes=known_classes)
+
+    print(f"GT     : {n_gt_imgs}장  {n_gt_objs}개 객체")
+    print(f"Pred   : {n_pred_objs}개 / {result['n_classes']}클래스 평가")
+    print(f"mAP@[0.50:0.95] : {result['mAP@[0.50:0.95]']:.4f}  (COCO)")
+    print(f"mAP@[0.75:0.95] : {result['mAP@[0.75:0.95]']:.4f}  (Kaggle)")
+    print(f"mAP@0.50        : {result['mAP@0.50']:.4f}")
+    print(f"mAP@0.75        : {result['mAP@0.75']:.4f}")
+
+    if args.per_class:
+        print("\n클래스별 AP@[0.75:0.95] (상위 20):")
+        for cls, aps in sorted(
+            result["per_class"].items(), key=lambda x: -x[1]["AP@[0.75:0.95]"]
+        )[:20]:
+            print(
+                f"  {cls:<45s} "
+                f"0.50={aps['AP@0.50']:.3f}  "
+                f"0.75={aps['AP@0.75']:.3f}  "
+                f"[0.75:0.95]={aps['AP@[0.75:0.95]']:.3f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pipeline/evaluate_pipeline.py
+++ b/scripts/pipeline/evaluate_pipeline.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -152,10 +151,11 @@ def compute_map(
     def _mean_ap(thrs: list[float]) -> float:
         if not ap_table:
             return 0.0
-        return float(np.mean([
-            np.mean([ap_table[cls].get(t, 0.0) for t in thrs])
-            for cls in ap_table
-        ]))
+        return float(
+            np.mean(
+                [np.mean([ap_table[cls].get(t, 0.0) for t in thrs]) for cls in ap_table]
+            )
+        )
 
     thrs_5095 = [t for t in iou_thrs if 0.50 <= t <= 0.95]
     thrs_7595 = [t for t in iou_thrs if 0.75 <= t <= 0.95]
@@ -164,8 +164,12 @@ def compute_map(
         cls: {
             "AP@0.50": ap_table[cls].get(0.50, 0.0),
             "AP@0.75": ap_table[cls].get(0.75, 0.0),
-            "AP@[0.50:0.95]": float(np.mean([ap_table[cls].get(t, 0.0) for t in thrs_5095])),
-            "AP@[0.75:0.95]": float(np.mean([ap_table[cls].get(t, 0.0) for t in thrs_7595])),
+            "AP@[0.50:0.95]": float(
+                np.mean([ap_table[cls].get(t, 0.0) for t in thrs_5095])
+            ),
+            "AP@[0.75:0.95]": float(
+                np.mean([ap_table[cls].get(t, 0.0) for t in thrs_7595])
+            ),
         }
         for cls in ap_table
     }
@@ -197,8 +201,11 @@ def load_gt(label_dir: Path, image_dir: Path) -> dict[str, list[dict]]:
         class_name = _normalize(_extract_class_name(stem))
 
         img_path = next(
-            (image_dir / f"{stem}{e}" for e in _IMAGE_EXTS
-             if (image_dir / f"{stem}{e}").exists()),
+            (
+                image_dir / f"{stem}{e}"
+                for e in _IMAGE_EXTS
+                if (image_dir / f"{stem}{e}").exists()
+            ),
             None,
         )
         if img_path is None:
@@ -212,13 +219,17 @@ def load_gt(label_dir: Path, image_dir: Path) -> dict[str, list[dict]]:
             if len(parts) < 5:
                 continue
             _, cx, cy, bw, bh = map(float, parts[:5])
-            gt[stem].append({
-                "bbox": [
-                    (cx - bw / 2) * W, (cy - bh / 2) * H,
-                    (cx + bw / 2) * W, (cy + bh / 2) * H,
-                ],
-                "class_name": class_name,
-            })
+            gt[stem].append(
+                {
+                    "bbox": [
+                        (cx - bw / 2) * W,
+                        (cy - bh / 2) * H,
+                        (cx + bw / 2) * W,
+                        (cy + bh / 2) * H,
+                    ],
+                    "class_name": class_name,
+                }
+            )
     return dict(gt)
 
 
@@ -242,11 +253,13 @@ def load_preds(
         s2 = s2_by_crop.get(crop["crop_id"])
         if s2 is None:
             continue
-        preds[crop["image_id"]].append({
-            "bbox": crop["bbox"],
-            "class_name": s2["class_name"],
-            "score": crop["score"] * s2["score"],
-        })
+        preds[crop["image_id"]].append(
+            {
+                "bbox": crop["bbox"],
+                "class_name": s2["class_name"],
+                "score": crop["score"] * s2["score"],
+            }
+        )
     return dict(preds), known_classes
 
 
@@ -256,11 +269,13 @@ def load_preds(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="2-Stage 파이프라인 end-to-end mAP 평가")
+    parser = argparse.ArgumentParser(
+        description="2-Stage 파이프라인 end-to-end mAP 평가"
+    )
     parser.add_argument("--gt-labels", required=True, help="YOLO label 디렉터리 (val)")
     parser.add_argument("--gt-images", required=True, help="원본 이미지 디렉터리 (val)")
-    parser.add_argument("--s1-crops",  required=True, help="Stage 1 crops manifest")
-    parser.add_argument("--s2-preds",  required=True, help="Stage 2 predictions JSON")
+    parser.add_argument("--s1-crops", required=True, help="Stage 1 crops manifest")
+    parser.add_argument("--s2-preds", required=True, help="Stage 2 predictions JSON")
     parser.add_argument("--per-class", action="store_true", help="클래스별 AP 출력")
     args = parser.parse_args()
 

--- a/scripts/pipeline/run_predict.py
+++ b/scripts/pipeline/run_predict.py
@@ -35,6 +35,7 @@ from src.utils.path import (
     resolve_weights_path,
 )
 from src.utils.submission import merge_predictions, save_submission
+from src.utils.timing import exp_dir_from_cfg, timed
 
 ROOT = PROJECT_ROOT
 SCRIPTS = ROOT / "scripts"
@@ -70,6 +71,7 @@ def main() -> None:
 
     stage1_cfg = load_config(args.stage1_config)
     stage2_cfg = load_config(args.stage2_config)
+    _exp_dir = exp_dir_from_cfg(stage1_cfg)
 
     stage1_weights = resolve_weights_path(stage1_cfg, args.stage1_weights)
     stage1_predictions = resolve_predictions_path(stage1_cfg, None)
@@ -78,62 +80,63 @@ def main() -> None:
     crop_output = resolve_project_path(args.crop_output)
     manifest_path = crop_output / "crops_manifest.json"
 
-    run_command(
-        [
-            sys.executable,
-            str(SCRIPTS / "predict.py"),
-            "--config",
-            args.stage1_config,
-            "--weights",
-            str(stage1_weights),
-            "--source",
-            args.source,
-            "--output",
-            str(stage1_predictions),
-        ],
-        f"Stage 1 추론: {args.source} → {stage1_predictions}",
-        cwd=ROOT,
-    )
+    with timed(_exp_dir, "pipeline_predict"):
+        run_command(
+            [
+                sys.executable,
+                str(SCRIPTS / "predict.py"),
+                "--config",
+                args.stage1_config,
+                "--weights",
+                str(stage1_weights),
+                "--source",
+                args.source,
+                "--output",
+                str(stage1_predictions),
+            ],
+            f"Stage 1 추론: {args.source} → {stage1_predictions}",
+            cwd=ROOT,
+        )
 
-    run_command(
-        [
-            sys.executable,
-            str(SCRIPTS / "pipeline" / "crop.py"),
-            "--predictions",
-            str(stage1_predictions),
-            "--source",
-            args.source,
-            "--output",
-            str(crop_output),
-            "--padding",
-            str(args.padding),
-        ],
-        f"crop 생성: {crop_output}",
-        cwd=ROOT,
-    )
+        run_command(
+            [
+                sys.executable,
+                str(SCRIPTS / "pipeline" / "crop.py"),
+                "--predictions",
+                str(stage1_predictions),
+                "--source",
+                args.source,
+                "--output",
+                str(crop_output),
+                "--padding",
+                str(args.padding),
+            ],
+            f"crop 생성: {crop_output}",
+            cwd=ROOT,
+        )
 
-    run_command(
-        [
-            sys.executable,
-            str(SCRIPTS / "pipeline" / "stage2_predict.py"),
-            "--config",
-            args.stage2_config,
-            "--weights",
-            str(stage2_weights),
-            "--source",
-            str(crop_output),
-            "--output",
-            str(stage2_predictions),
-        ],
-        f"Stage 2 추론: {crop_output} → {stage2_predictions}",
-        cwd=ROOT,
-    )
+        run_command(
+            [
+                sys.executable,
+                str(SCRIPTS / "pipeline" / "stage2_predict.py"),
+                "--config",
+                args.stage2_config,
+                "--weights",
+                str(stage2_weights),
+                "--source",
+                str(crop_output),
+                "--output",
+                str(stage2_predictions),
+            ],
+            f"Stage 2 추론: {crop_output} → {stage2_predictions}",
+            cwd=ROOT,
+        )
 
-    print("[실행] 결과 병합 및 submission 생성 중...")
-    merged = merge_predictions(manifest_path, stage2_predictions)
-    output_path = resolve_project_path(args.output)
-    save_submission(merged, output_path)
-    print(f"[완료] submission.csv → {output_path}")
+        print("[실행] 결과 병합 및 submission 생성 중...")
+        merged = merge_predictions(manifest_path, stage2_predictions)
+        output_path = resolve_project_path(args.output)
+        save_submission(merged, output_path)
+        print(f"[완료] submission.csv → {output_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/pipeline/run_predict.py
+++ b/scripts/pipeline/run_predict.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
@@ -35,47 +34,10 @@ from src.utils.path import (
     resolve_stage2_predictions_path,
     resolve_weights_path,
 )
-from src.utils.submission import save_submission
+from src.utils.submission import merge_predictions, save_submission
 
 ROOT = PROJECT_ROOT
 SCRIPTS = ROOT / "scripts"
-
-
-def merge_predictions(
-    manifest_path: str | Path, stage2_predictions_path: str | Path
-) -> list[dict]:
-    """Stage 2 예측 결과와 크롭 manifest를 crop_id 기준으로 병합한다.
-
-    Returns:
-        image_id별 detections 리스트 [{"image_id", "detections": [{"class_id", "class_name", "bbox", "score"}]}]
-    """
-    with Path(manifest_path).open(encoding="utf-8") as f:
-        manifest = json.load(f)
-    with Path(stage2_predictions_path).open(encoding="utf-8") as f:
-        stage2_predictions = json.load(f)
-
-    manifest_by_crop = {item["crop_id"]: item for item in manifest}
-    merged_by_image: dict[str, list[dict]] = {}
-
-    for record in stage2_predictions:
-        crop_id = record["crop_id"]
-        manifest_item = manifest_by_crop.get(crop_id)
-        if manifest_item is None:
-            raise KeyError(f"manifest에 없는 crop_id: {crop_id}")
-        merged_by_image.setdefault(record["image_id"], []).append(
-            {
-                "class_id": record["class_id"],
-                "class_name": record["class_name"],
-                "bbox": manifest_item["bbox"],
-                "score": record["score"],
-            }
-        )
-
-    image_ids = {item["image_id"] for item in manifest}
-    return [
-        {"image_id": iid, "detections": merged_by_image.get(iid, [])}
-        for iid in sorted(image_ids)
-    ]
 
 
 def main() -> None:

--- a/scripts/pipeline/stage2_predict.py
+++ b/scripts/pipeline/stage2_predict.py
@@ -19,6 +19,7 @@ sys.path.insert(
 
 from src.models.classifier import Classifier
 from src.utils.config import load_config
+from src.utils.timing import exp_dir_from_cfg, timed
 
 
 def main() -> None:
@@ -37,7 +38,8 @@ def main() -> None:
     output = args.output or _resolve_output(cfg)
 
     classifier = Classifier(cfg).load_weights(weights)
-    results = classifier.predict(source=args.source, output=output)
+    with timed(exp_dir_from_cfg(cfg), "s2_predict"):
+        results = classifier.predict(source=args.source, output=output)
     print(f"추론 완료: {len(results)}개 → {output}")
 
 

--- a/scripts/pipeline/stage2_train.py
+++ b/scripts/pipeline/stage2_train.py
@@ -22,6 +22,7 @@ from torch.utils.data import DataLoader
 from src.data.stage2_dataset import Stage2Dataset
 from src.models.classifier import Classifier
 from src.utils.config import load_config
+from src.utils.timing import exp_dir_from_cfg, timed
 
 
 def main() -> None:
@@ -67,7 +68,8 @@ def main() -> None:
 
     classifier = Classifier(cfg)
     classifier.class_names = train_ds.classes
-    metrics = classifier.fit(train_loader, val_loader)
+    with timed(exp_dir_from_cfg(cfg), "s2_train"):
+        metrics = classifier.fit(train_loader, val_loader)
     print(f"학습 완료: top1={metrics['top1_acc']:.4f}, top5={metrics['top5_acc']:.4f}")
 
 

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -26,6 +26,7 @@ sys.path.insert(
 from src.models.model_yolo import YOLOModel
 from src.models.predictor import Predictor
 from src.utils.path import resolve_weights_path, resolve_predictions_path
+from src.utils.timing import exp_dir_from_cfg, timed
 
 
 def main():
@@ -62,7 +63,8 @@ def main():
     # 우선순위: CLI --tta > config val.tta
     tta = args.tta or cfg["val"].get("tta", False)
 
-    predictions = Predictor(model).predict(args.source, output=output, tta=tta)
+    with timed(exp_dir_from_cfg(cfg), "s1_predict"):
+        predictions = Predictor(model).predict(args.source, output=output, tta=tta)
     print(f"완료: {len(predictions)}개 이미지 → {output}")
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,6 +23,7 @@ sys.path.insert(
 
 from src.models.model_yolo import YOLOModel
 from src.training.trainer import Trainer
+from src.utils.timing import exp_dir_from_cfg, timed
 
 
 def main():
@@ -41,7 +42,8 @@ def main():
     if args.device is not None:
         model.cfg["train"]["device"] = args.device
 
-    metrics = Trainer(model).train(data_yaml=args.data)
+    with timed(exp_dir_from_cfg(model.cfg), "s1_train"):
+        metrics = Trainer(model).train(data_yaml=args.data)
     print(f"mAP50={metrics['mAP50']:.4f}  mAP50-95={metrics['mAP50_95']:.4f}")
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -26,6 +26,7 @@ sys.path.insert(
 from src.models.model_yolo import YOLOModel
 from src.training.trainer import Trainer
 from src.utils.path import resolve_weights_path
+from src.utils.timing import exp_dir_from_cfg, timed
 
 
 def main():
@@ -48,7 +49,8 @@ def main():
     weights = resolve_weights_path(cfg, args.weights)
     model.load_weights(str(weights))
 
-    metrics = Trainer(model).validate(data_yaml=args.data)
+    with timed(exp_dir_from_cfg(cfg), "s1_validate"):
+        metrics = Trainer(model).validate(data_yaml=args.data)
     print(f"mAP50={metrics['mAP50']:.4f}  mAP50-95={metrics['mAP50_95']:.4f}")
 
 

--- a/src/models/classifier.py
+++ b/src/models/classifier.py
@@ -40,7 +40,7 @@ class Classifier:
 
     def load_weights(self, path: str | Path) -> "Classifier":
         """체크포인트 또는 state_dict를 로드한다."""
-        checkpoint = torch.load(path, map_location="cpu")
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
         if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
             state_dict = checkpoint["model_state_dict"]
             self.class_names = list(checkpoint.get("class_names", self.class_names))

--- a/src/utils/submission.py
+++ b/src/utils/submission.py
@@ -14,28 +14,32 @@ def merge_predictions(
 ) -> list[dict]:
     """crops_manifest + stage2 predictions → image_id별 detections 병합.
 
+    score = det_score (manifest) * cls_score (stage2).
+
     Returns:
         [{"image_id": str, "detections": [{"class_id", "class_name", "bbox", "score"}]}]
     """
     with Path(manifest_path).open(encoding="utf-8") as f:
         manifest = json.load(f)
     with Path(stage2_predictions_path).open(encoding="utf-8") as f:
-        stage2_predictions = json.load(f)
+        stage2_preds = json.load(f)
 
     manifest_by_crop = {item["crop_id"]: item for item in manifest}
     merged_by_image: dict[str, list[dict]] = {}
 
-    for record in stage2_predictions:
+    for record in stage2_preds:
         crop_id = record["crop_id"]
-        manifest_item = manifest_by_crop.get(crop_id)
-        if manifest_item is None:
+        m = manifest_by_crop.get(crop_id)
+        if m is None:
             raise KeyError(f"manifest에 없는 crop_id: {crop_id}")
+        det_score = float(m.get("score", 1.0))
+        cls_score = float(record["score"])
         merged_by_image.setdefault(record["image_id"], []).append(
             {
                 "class_id": record["class_id"],
                 "class_name": record["class_name"],
-                "bbox": manifest_item["bbox"],
-                "score": record["score"],
+                "bbox": m["bbox"],
+                "score": det_score * cls_score,
             }
         )
 
@@ -46,19 +50,38 @@ def merge_predictions(
     ]
 
 
-def predictions_to_df(predictions: list[dict]) -> pd.DataFrame:
-    """predictions 리스트 → Kaggle submission DataFrame."""
+def predictions_to_df(
+    predictions: list[dict],
+    class_map: dict[str, int] | None = None,
+    image_id_map: dict[str, int] | None = None,
+) -> pd.DataFrame:
+    """predictions 리스트 → Kaggle submission DataFrame.
+
+    Args:
+        predictions: merge_predictions() 반환값.
+        class_map: {class_name: category_id}. None이면 내부 class_id 사용.
+        image_id_map: {filename_stem: int}. None이면 image_id 문자열 그대로 사용.
+    """
     rows = []
     annotation_id = 1
     for item in predictions:
-        image_id = item["image_id"]
+        raw_image_id = item["image_id"]
+        image_id = (
+            image_id_map.get(raw_image_id, raw_image_id)
+            if image_id_map
+            else raw_image_id
+        )
         for det in item["detections"]:
             x1, y1, x2, y2 = det["bbox"]
+            if class_map is not None:
+                category_id = class_map.get(det["class_name"], det["class_id"])
+            else:
+                category_id = det["class_id"]
             rows.append(
                 {
                     "annotation_id": annotation_id,
                     "image_id": image_id,
-                    "category_id": det["class_id"],
+                    "category_id": category_id,
                     "bbox_x": round(x1),
                     "bbox_y": round(y1),
                     "bbox_w": round(x2 - x1),
@@ -70,8 +93,15 @@ def predictions_to_df(predictions: list[dict]) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def save_submission(predictions: list[dict], output: str | Path) -> None:
+def save_submission(
+    predictions: list[dict],
+    output: str | Path,
+    class_map: dict[str, int] | None = None,
+    image_id_map: dict[str, int] | None = None,
+) -> None:
     """predictions → CSV 저장."""
     out = Path(output)
     out.parent.mkdir(parents=True, exist_ok=True)
-    predictions_to_df(predictions).to_csv(out, index=False)
+    predictions_to_df(predictions, class_map=class_map, image_id_map=image_id_map).to_csv(
+        out, index=False
+    )

--- a/src/utils/submission.py
+++ b/src/utils/submission.py
@@ -102,6 +102,6 @@ def save_submission(
     """predictions → CSV 저장."""
     out = Path(output)
     out.parent.mkdir(parents=True, exist_ok=True)
-    predictions_to_df(predictions, class_map=class_map, image_id_map=image_id_map).to_csv(
-        out, index=False
-    )
+    predictions_to_df(
+        predictions, class_map=class_map, image_id_map=image_id_map
+    ).to_csv(out, index=False)

--- a/src/utils/submission.py
+++ b/src/utils/submission.py
@@ -1,12 +1,53 @@
-"""제출 파일 변환 유틸. predictions.json → Kaggle submission CSV."""
+"""제출 파일 변환 유틸. crops_manifest + stage2_preds → Kaggle submission CSV."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import pandas as pd
 
 
+def merge_predictions(
+    manifest_path: str | Path,
+    stage2_predictions_path: str | Path,
+) -> list[dict]:
+    """crops_manifest + stage2 predictions → image_id별 detections 병합.
+
+    Returns:
+        [{"image_id": str, "detections": [{"class_id", "class_name", "bbox", "score"}]}]
+    """
+    with Path(manifest_path).open(encoding="utf-8") as f:
+        manifest = json.load(f)
+    with Path(stage2_predictions_path).open(encoding="utf-8") as f:
+        stage2_predictions = json.load(f)
+
+    manifest_by_crop = {item["crop_id"]: item for item in manifest}
+    merged_by_image: dict[str, list[dict]] = {}
+
+    for record in stage2_predictions:
+        crop_id = record["crop_id"]
+        manifest_item = manifest_by_crop.get(crop_id)
+        if manifest_item is None:
+            raise KeyError(f"manifest에 없는 crop_id: {crop_id}")
+        merged_by_image.setdefault(record["image_id"], []).append(
+            {
+                "class_id": record["class_id"],
+                "class_name": record["class_name"],
+                "bbox": manifest_item["bbox"],
+                "score": record["score"],
+            }
+        )
+
+    image_ids = {item["image_id"] for item in manifest}
+    return [
+        {"image_id": iid, "detections": merged_by_image.get(iid, [])}
+        for iid in sorted(image_ids)
+    ]
+
+
 def predictions_to_df(predictions: list[dict]) -> pd.DataFrame:
-    """predictions.json 리스트 → submission DataFrame (xywh, annotation_id 포함)."""
+    """predictions 리스트 → Kaggle submission DataFrame."""
     rows = []
     annotation_id = 1
     for item in predictions:
@@ -30,7 +71,7 @@ def predictions_to_df(predictions: list[dict]) -> pd.DataFrame:
 
 
 def save_submission(predictions: list[dict], output: str | Path) -> None:
-    """predictions_to_df 호출 후 CSV로 저장한다."""
+    """predictions → CSV 저장."""
     out = Path(output)
     out.parent.mkdir(parents=True, exist_ok=True)
     predictions_to_df(predictions).to_csv(out, index=False)

--- a/tests/test_pipeline_run.py
+++ b/tests/test_pipeline_run.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from scripts.pipeline.run_predict import (
     merge_predictions,
 )
@@ -76,17 +78,14 @@ def test_merge_predictions_with_manifest(tmp_path):
     )
 
     merged = merge_predictions(manifest_path, stage2_path)
-    assert merged == [
-        {
-            "image_id": "test_0001",
-            "detections": [
-                {
-                    "class_id": 42,
-                    "class_name": "Crestor 10mg tab",
-                    "bbox": [120.0, 45.0, 380.0, 210.0],
-                    "score": 0.912,
-                }
-            ],
-        },
-        {"image_id": "test_0002", "detections": []},
-    ]
+    assert len(merged) == 2
+    assert merged[1] == {"image_id": "test_0002", "detections": []}
+
+    det = merged[0]
+    assert det["image_id"] == "test_0001"
+    assert len(det["detections"]) == 1
+    d = det["detections"][0]
+    assert d["class_id"] == 42
+    assert d["class_name"] == "Crestor 10mg tab"
+    assert d["bbox"] == [120.0, 45.0, 380.0, 210.0]
+    assert d["score"] == pytest.approx(0.91 * 0.912)


### PR DESCRIPTION
## 📌 변경 개요
> evaluate_pipeline.py로 end-to-end mAP 측정을 자동화하고, make_submission.py를 2-stage 인터페이스로 교체했습니다.

---

## 📋 변경 유형

- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 / 모듈 추가
- [ ] 🔬 실험 (exp/ 브랜치에서 main 병합 시)
- [ ] 📊 데이터 전처리 / 증강
- [ ] 📝 문서 / 주석
- [ ] 🔧 설정 / 환경
- [ ] ♻️ 리팩토링
---

## 📋 주요 변경
  - scripts/pipeline/evaluate_pipeline.py 추가 — e2e mAP 자동 측정
  - 파이프라인 스크립트 전체에 timed() 래핑 (crop, run_predict, stage2_predict)
  - make_submission.py — 2-stage 인터페이스로 교체, det×cls 점수 개선,
                          Kaggle image ID 매핑 지원
  - src/utils/submission.py — merge_predictions 로직 이전 (run_predict에서 분리)
  - [fix] classifier: torch.load weights_only=False 명시

---

## 🧪 테스트 / 검증 방법

> 변경 사항을 어떻게 검증했는지 설명하세요.

```bash
# 예시: smoke test 명령어
python -m pytest -v
```

- [x] 로컬에서 직접 실행 확인
- [ ] Colab / Kaggle Kernel에서 실행 확인 (해당 시)

---

## ⚠️ 리뷰어 주의사항

> 선행 PR인 feat/Nighthom-utils 머지 후에 머지해 주세요.

---

## ✅ PR 제출 전 체크리스트

- [x] `ruff check .` 통과
- [x] `black --check .` 통과
- [x] 새 모듈에 docstring 작성
- [x] 예외 처리 포함 여부 확인
- [x] `.gitignore` 대상 파일(가중치, 이미지, 로그)이 포함되지 않았는지 확인
- [x] `data/raw/` 원본 데이터 수정 없음 확인
- [x] 금지 데이터(`TL_2_조합.zip`, `TS_2_조합.zip`) 미사용 확인

---

## 💬 기타

> 이번에는 main에 바로 머지하는게 아니라 선행 브랜치로 merge되게끔 진행해 보았습니다.    
> 리뷰하시는 입장에서 어떤 방식이 더 편한지 의견 남겨주시면 수용하겠습니다.    

> 죄송합니다. main에 머지를 안하고, 다른 Branch에 머지를 해버려서 main에 반영이 안 되었습니다. 한번만 더 Review해 주시면 감사하겠습니다.