### PR TITLE
[fix] pyproject.toml에 scripts* 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ requires-python = ">=3.10"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["src*"]
+include = ["src*", "scripts*"]


### PR DESCRIPTION
## 📌 변경 개요

> pyproject.toml에 scripts*가 없어 pip install -e를 해도 scripts 모듈을 가져오지 못하던 오류를 수정합니다.

---

## 🔗 관련 이슈

- Closes #115 

---

## 📋 변경 유형

- [x] 🐛 버그 수정
- [ ] ✨ 새 기능 / 모듈 추가
- [ ] 🔬 실험 (exp/ 브랜치에서 main 병합 시)
- [ ] 📊 데이터 전처리 / 증강
- [ ] 📝 문서 / 주석
- [ ] 🔧 설정 / 환경
- [ ] ♻️ 리팩토링

---

## 🧪 테스트 / 검증 방법

> 변경 사항을 어떻게 검증했는지 설명하세요.
프로젝트 경로에서 pip install -e .를 실행하고 난 이후, 프로젝트 경로 외에서도 scripts 모듈이 제대로 임포트되는지 확인합니다. 
- [x] 로컬에서 직접 실행 확인
- [ ] Colab / Kaggle Kernel에서 실행 확인 (해당 시)

---

## ✅ PR 제출 전 체크리스트

- [x] `ruff check .` 통과
- [x] `black --check .` 통과
- [x] 새 모듈에 docstring 작성
- [x] 예외 처리 포함 여부 확인
- [x] `.gitignore` 대상 파일(가중치, 이미지, 로그)이 포함되지 않았는지 확인
- [x] `data/raw/` 원본 데이터 수정 없음 확인
- [x] 금지 데이터(`TL_2_조합.zip`, `TS_2_조합.zip`) 미사용 확인

---
